### PR TITLE
Search by tag name and get latest relese tag name

### DIFF
--- a/travis-helpers.sh
+++ b/travis-helpers.sh
@@ -262,7 +262,7 @@ gitHub_releases()
 
 gitHub_release_named()
 {
-   namedReleaseAsJSON=$(gitHub_releases ${1} | jq -r --arg releaseName ${2-$release} '.[] | select(.name==$releaseName)')
+   namedReleaseAsJSON=$(gitHub_releases ${1} | jq -r --arg releaseName ${2-$release} '.[] | select(.tag_name==$releaseName)')
    echo ${namedReleaseAsJSON}
 }
 
@@ -270,6 +270,12 @@ gitHub_release_latest()
 {
    latestReleaseAsJSON=$(gitHub_releases ${1} | jq -r 'max_by(.id)')
    echo ${latestReleaseAsJSON}
+}
+
+gitHub_release_latest_freecad()
+{
+   latestReleaseAsTagName=$(curl -s "https://api.github.com/repos/FreeCAD/FreeCAD/releases/latest" | jq -r .tag_name)
+   echo ${latestReleaseAsTagName}
 }
 
 ####


### PR DESCRIPTION
We currently use travis-helpers.sh script for AppImage and macOS deployment purposes (Conda builds).

https://github.com/FreeCAD/FreeCAD-AppImage

Proposed changes include identifying named releases by a tag name and not by name anymore, as they can differ and tag name is what we are after. Function to retrieve the latest FreeCAD release tag name was added.

https://forum.freecadweb.org/viewtopic.php?f=10&t=34981